### PR TITLE
docs: clarify refactor retrieve step

### DIFF
--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -769,7 +769,9 @@ Adapters: OpenRouter, OpenAI, Anthropic, Ollama/LM Studio.
 1) **Interpret** the instruction → a structured **Edit Plan**:
    - `targets` (entities, locations, motifs), `operations` (add vocal tic, change setting), `constraints` (voice, POV), `scope`.
 2) **Retrieve** candidate spans:
-   - Use **SceneEntity** links + embeddings (sentences/paragraphs) + simple heuristics (quote attribution for dialogue).
+   - **Sentence segmentation** of the scene and embedding search over those units.
+   - Heuristics flag `isDialogue` (leading/trailing quotes, em‑dash openings) and attempt **speaker attribution** from nearby tags ("X said", existing annotations).
+   - Use **SceneEntity** links + embeddings to gather spans; when a `speakerId` is supplied, filter to sentences attributed to that speaker for targeted refactors.
 3) **Rewrite** per span:
    - Compose local context (surrounding sentences, Canon facts, style guide). Ask model for revised text + rationale.
 4) **Assemble patches**:


### PR DESCRIPTION
## Summary
- elaborate on Refactor Chat's retrieval step, covering sentence segmentation, dialogue heuristics, and speaker filtering

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_689eca12f6188324a40bebac3497a74a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated retrieval spec to use sentence-level search with improved dialogue detection and speaker attribution.
  * Documented per-speaker filtering: when a speaker is specified, only that speaker’s sentences are considered for targeted refactors.
  * Clarified that downstream steps (rewrite and patch assembly) remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->