### PR TITLE
docs: document patch apply endpoint

### DIFF
--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -683,6 +683,27 @@ paths:
                 patchIds: { type: array, items: { type: string } } # if omitted, apply all ACCEPTED
       responses:
         '200': { description: Apply result per patch }
+  /patches/{patchId}/apply:
+    post:
+      summary: Apply selected hunks
+      parameters:
+        - in: header
+          name: X-Idempotency-Key
+          schema: { type: string }
+        - in: header
+          name: If-Match
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                hunkIds: { type: array, items: { type: string } } # if omitted, apply all
+      responses:
+        '200': { description: Patch applied }
+        '412': { description: Precondition failed }
+        '409': { description: Patch conflict }
   /generate:
     post:
       summary: Run model action with composed context


### PR DESCRIPTION
## Summary
- document `/patches/{patchId}/apply` endpoint with headers, request body, and responses

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689eca11cfa88324ac7ede7528efd977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added POST /patches/{patchId}/apply to apply selected hunks of a patch via hunkIds, enabling granular application.
  * Supports idempotent retries with X-Idempotency-Key and optimistic locking via If-Match (ETag).
  * Returns clear outcomes: 200 (applied), 409 (conflict), 412 (precondition failed).
  * Existing POST /refactors/{id}/apply remains unchanged.

* **Documentation**
  * Updated API specification to cover the new endpoint, headers, request body, and response codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->