### PR TITLE
docs: add PatchProposal schema

### DIFF
--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -613,7 +613,34 @@ components:
       type: object
       properties:
         changes: { type: array, items: { type: object, properties: { sceneId: { $ref: '#/components/schemas/ID' }, before: { type: string }, after: { type: string } } } }
-paths:
+    PatchProposal:
+      type: object
+      required: [id, sceneId, summary, hunks]
+      properties:
+        id: { $ref: '#/components/schemas/ID' }
+        sceneId: { $ref: '#/components/schemas/ID' }
+        summary: { type: string }
+        confidence: { type: number, format: float }
+        hunks:
+          type: array
+          items:
+            type: object
+            required: [op, origStart, origEnd, newText, anchors]
+            properties:
+              op: { type: string, enum: [REPLACE, INSERT, DELETE] }
+              origStart: { type: integer, description: 'start index in original text' }
+              origEnd: { type: integer, description: 'end index in original text' }
+              newText: { type: string, description: 'proposed replacement text' }
+              anchors:
+                type: object
+                description: 'Anchors to re-locate hunk if doc changes'
+                properties:
+                  before: { type: string, description: 'k-gram preceding hunk' }
+                  after: { type: string, description: 'k-gram following hunk' }
+                  yjs:
+                    type: object
+                    description: 'Yjs RelativePosition'
+    paths:
   /projects:
     get:
       summary: List projects
@@ -698,8 +725,10 @@ paths:
   /budgets/{projectId}:
     get: { summary: Get budget, responses: { '200': { description: OK } } }
     patch: { summary: Update budget, responses: { '200': { description: OK } } }
-components: {}
+  components: {}
 ```
+
+API providers must return `PatchProposal[]`.
 
 ### WebSocket Events
 


### PR DESCRIPTION
## Summary
- describe PatchProposal object with hunk and anchor structure
- clarify API providers must return PatchProposal[]

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689eca10540c8324a9a83d5365e5c61c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced patch proposal responses for refactors, supporting multiple hunks with operations (insert/replace/delete), confidence scores, and relocation anchors for robust application.
  - Relevant endpoints now return an array of patch proposals.

- Documentation
  - Updated the OpenAPI spec to include the patch proposal model and hunk structure.
  - Clarified that API providers must return arrays of patch proposals.
  - Reorganized the WebSocket/events section by removing group headers while keeping all concrete events (e.g., client/server, presence, editor, comments, suggestions, run, cost, refactor).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->