### PR TITLE
docs: outline transport and safety headers for API

### DIFF
--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -797,6 +797,18 @@ interface ProviderAdapter {
 ```
 Adapters: OpenRouter, OpenAI, Anthropic, Ollama/LM Studio.
 
+#### Transport & Headers (performance + safety)
+
+- **Transport choices**
+  - HTTP/1.1 for immediate compatibility
+  - Consider HTTP/2 or gRPC for streaming and multiplexing
+- **Safety headers**
+  - `X-Idempotency-Key` to guard against accidental retries
+  - `If-Match` with ETags to prevent lost updates
+- **Error semantics**
+  - `409 Conflict` for edit collisions
+  - `412 Precondition Failed` when safety headers are missing or stale
+
 ## 8. Context Builder Algorithm
 1. **Selection**  
    - Active scene S, plus `N` previous scene **summaries** (configurable).  


### PR DESCRIPTION
## Summary
- detail transport options and safety headers for API endpoints
- document error semantics for edit collisions and stale preconditions

## Testing
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_689ecb5efe6883248d1adbf1d4235500