### PR TITLE
docs: add backend framework ADR

### DIFF
--- a/docs/adr/0001-backend-framework.md
+++ b/docs/adr/0001-backend-framework.md
@@ -1,0 +1,28 @@
+# 0001: Backend Framework
+
+## Status
+Accepted
+
+## Date
+2025-08-15
+
+## Context
+We need a performant and well-supported Node.js framework for building the service's APIs.
+The framework must offer strong TypeScript support, extensibility, and high throughput to handle collaborative features.
+
+## Decision
+Adopt **Fastify** as the primary backend framework.
+
+## Alternatives
+- **Express**: Ubiquitous and simple but slower and less opinionated.
+- **Koa**: Minimalist design requiring additional libraries for common tasks.
+- **NestJS**: Feature-rich but introduces unnecessary complexity and learning overhead.
+
+## Consequences
+- Benefit from Fastify's plugin ecosystem and performance optimizations.
+- Team members must familiarize themselves with Fastify conventions.
+- Some middleware available for Express may not yet exist for Fastify.
+
+## Migration Notes
+- Translate existing Express-style middleware into Fastify plugins.
+- Validate request and response schemas to leverage Fastify's type system.


### PR DESCRIPTION
## Summary
- document decision to adopt Fastify as backend framework
- note alternatives, consequences, and migration details

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689ecb6149d88324b74a16c1356267be