### PR TITLE
docs: detail API stack with NestJS and FastifyAdapter

### DIFF
--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -16,7 +16,9 @@
 - **License:** Recommend MPL-2.0 for file-level copyleft that encourages plugin ecosystem while allowing proprietary extensions. Apache-2.0 lacks copyleft; AGPL-3.0 enforces networked source distribution, which may deter commercial contributors. MPL-2.0 balances openness and adoption.
 - **Tech Stack:**
   - Web: TypeScript + Next.js
-  - API: Node.js + Fastify (WebSocket support)
+  - API:
+    - Node.js + NestJS
+    - FastifyAdapter (WebSocket support)
   - Database: PostgreSQL with pgvector; Redis for ephemeral state
   - Editor: TipTap (ProseMirror) with Markdown I/O
   - Realtime: Yjs CRDTs


### PR DESCRIPTION
## Summary
- expand API tech stack to NestJS with FastifyAdapter for WebSockets

## Testing
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_689ecb5ee0708324bbeb8eceb043c85b