### PR TITLE
feat(db): initialize prisma

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,9 @@
+# Local Infrastructure
+
+Start the supporting services:
+
+```bash
+docker compose up -d
+pnpm db:migrate
+pnpm db:seed
+```

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,19 +1,23 @@
-version: '3'
+version: '3.9'
 services:
   db:
     image: postgres:15
+    restart: unless-stopped
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_USER: nelo
+      POSTGRES_PASSWORD: nelo
+      POSTGRES_DB: nelo
     ports:
       - '5432:5432'
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
   redis:
     image: redis:7
+    restart: unless-stopped
     ports:
       - '6379:6379'
-  api:
-    build: ../apps/api
-    command: node dist/index.js
-    depends_on: [db, redis]
-  web:
-    build: ../apps/web
-    depends_on: [api]
+    volumes:
+      - redis-data:/data
+volumes:
+  postgres-data:
+  redis-data:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "license": "MPL-2.0",
   "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "db:migrate": "pnpm --filter @nelo/db exec prisma migrate deploy",
+    "db:seed": "pnpm --filter @nelo/db exec prisma db seed"
+  },
   "devDependencies": {
     "typescript": "^5.3.0",
     "vitest": "^0.34.0"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@nelo/db",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "generate": "prisma generate",
+    "db:migrate": "prisma migrate deploy",
+    "db:seed": "prisma db seed",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.10.2"
+  },
+  "devDependencies": {
+    "prisma": "^5.10.2",
+    "ts-node": "^10.9.1"
+  },
+  "prisma": {
+    "seed": "node --loader ts-node/esm src/seed.ts"
+  }
+}

--- a/packages/db/prisma/migrations/0001_init/migration.sql
+++ b/packages/db/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,303 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "vector";
+
+-- CreateEnum
+CREATE TYPE "RunStatus" AS ENUM ('PENDING', 'RUNNING', 'COMPLETE', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('OWNER', 'MEMBER');
+
+-- CreateTable
+CREATE TABLE "Project" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Book" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Book_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Chapter" (
+    "id" TEXT NOT NULL,
+    "bookId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "order" INTEGER,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Chapter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Scene" (
+    "id" TEXT NOT NULL,
+    "chapterId" TEXT NOT NULL,
+    "content" TEXT,
+    "order" INTEGER,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Scene_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Entity" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Entity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CanonFact" (
+    "id" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CanonFact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ContextRule" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "pattern" TEXT NOT NULL,
+    "response" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ContextRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Run" (
+    "id" TEXT NOT NULL,
+    "sceneId" TEXT,
+    "status" "RunStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Run_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CostEvent" (
+    "id" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CostEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Refactor" (
+    "id" TEXT NOT NULL,
+    "sceneId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Refactor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Patch" (
+    "id" TEXT NOT NULL,
+    "refactorId" TEXT NOT NULL,
+
+    CONSTRAINT "Patch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Hunk" (
+    "id" TEXT NOT NULL,
+    "patchId" TEXT NOT NULL,
+
+    CONSTRAINT "Hunk_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EditSpan" (
+    "id" TEXT NOT NULL,
+    "hunkId" TEXT NOT NULL,
+    "start" INTEGER NOT NULL,
+    "end" INTEGER NOT NULL,
+
+    CONSTRAINT "EditSpan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Snapshot" (
+    "id" TEXT NOT NULL,
+    "sceneId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Snapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Sentence" (
+    "id" TEXT NOT NULL,
+    "snapshotId" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "Sentence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StyleGuide" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "rules" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StyleGuide_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Membership" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+
+    CONSTRAINT "Membership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Budget" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Budget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProviderKey" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "apiKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProviderKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SceneEntity" (
+    "sceneId" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+
+    CONSTRAINT "SceneEntity_pkey" PRIMARY KEY ("sceneId","entityId")
+);
+
+-- CreateTable
+CREATE TABLE "Embedding" (
+    "id" TEXT NOT NULL,
+    "sceneId" TEXT,
+    "embedding" vector NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Embedding_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- AddForeignKey
+ALTER TABLE "Book" ADD CONSTRAINT "Book_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Chapter" ADD CONSTRAINT "Chapter_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scene" ADD CONSTRAINT "Scene_chapterId_fkey" FOREIGN KEY ("chapterId") REFERENCES "Chapter"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Entity" ADD CONSTRAINT "Entity_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CanonFact" ADD CONSTRAINT "CanonFact_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "Entity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ContextRule" ADD CONSTRAINT "ContextRule_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Run" ADD CONSTRAINT "Run_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "Scene"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CostEvent" ADD CONSTRAINT "CostEvent_runId_fkey" FOREIGN KEY ("runId") REFERENCES "Run"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Refactor" ADD CONSTRAINT "Refactor_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "Scene"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Patch" ADD CONSTRAINT "Patch_refactorId_fkey" FOREIGN KEY ("refactorId") REFERENCES "Refactor"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Hunk" ADD CONSTRAINT "Hunk_patchId_fkey" FOREIGN KEY ("patchId") REFERENCES "Patch"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EditSpan" ADD CONSTRAINT "EditSpan_hunkId_fkey" FOREIGN KEY ("hunkId") REFERENCES "Hunk"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Snapshot" ADD CONSTRAINT "Snapshot_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "Scene"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Sentence" ADD CONSTRAINT "Sentence_snapshotId_fkey" FOREIGN KEY ("snapshotId") REFERENCES "Snapshot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StyleGuide" ADD CONSTRAINT "StyleGuide_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Budget" ADD CONSTRAINT "Budget_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderKey" ADD CONSTRAINT "ProviderKey_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SceneEntity" ADD CONSTRAINT "SceneEntity_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "Scene"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SceneEntity" ADD CONSTRAINT "SceneEntity_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "Entity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Embedding" ADD CONSTRAINT "Embedding_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "Scene"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/packages/db/prisma/migrations/0002_embedding_index/migration.sql
+++ b/packages/db/prisma/migrations/0002_embedding_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Embedding_embedding_idx" ON "Embedding" USING ivfflat ("embedding") WITH (lists = 100);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,228 @@
+// Prisma schema for Nelo database
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
+}
+
+datasource db {
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [vector]
+}
+
+enum RunStatus {
+  PENDING
+  RUNNING
+  COMPLETE
+  FAILED
+}
+
+enum Role {
+  OWNER
+  MEMBER
+}
+
+model Project {
+  id           String        @id @default(uuid())
+  name         String
+  version      Int           @default(1)
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  books        Book[]
+  styleGuides  StyleGuide[]
+  budgets      Budget[]
+  users        Membership[]
+  providerKeys ProviderKey[]
+  entities     Entity[]
+  contextRules ContextRule[]
+}
+
+model Book {
+  id        String   @id @default(uuid())
+  project   Project  @relation(fields: [projectId], references: [id])
+  projectId String
+  title     String
+  version   Int      @default(1)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  chapters  Chapter[]
+}
+
+model Chapter {
+  id        String   @id @default(uuid())
+  book      Book     @relation(fields: [bookId], references: [id])
+  bookId    String
+  title     String
+  order     Int?
+  version   Int      @default(1)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  scenes    Scene[]
+}
+
+model Scene {
+  id         String       @id @default(uuid())
+  chapter    Chapter      @relation(fields: [chapterId], references: [id])
+  chapterId  String
+  content    String?
+  order      Int?
+  version    Int          @default(1)
+  createdAt  DateTime     @default(now())
+  updatedAt  DateTime     @updatedAt
+  snapshots  Snapshot[]
+  entities   SceneEntity[]
+  embeddings Embedding[]
+  runs       Run[]
+  refactors  Refactor[]
+}
+
+model Entity {
+  id        String       @id @default(uuid())
+  project   Project      @relation(fields: [projectId], references: [id])
+  projectId String
+  name      String
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  facts     CanonFact[]
+  scenes    SceneEntity[]
+}
+
+model CanonFact {
+  id        String   @id @default(uuid())
+  entity    Entity   @relation(fields: [entityId], references: [id])
+  entityId  String
+  content   String
+  createdAt DateTime @default(now())
+}
+
+model ContextRule {
+  id        String   @id @default(uuid())
+  project   Project  @relation(fields: [projectId], references: [id])
+  projectId String
+  pattern   String
+  response  String
+  createdAt DateTime @default(now())
+}
+
+model Run {
+  id        String     @id @default(uuid())
+  scene     Scene?     @relation(fields: [sceneId], references: [id])
+  sceneId   String?
+  status    RunStatus  @default(PENDING)
+  createdAt DateTime   @default(now())
+  costEvents CostEvent[]
+}
+
+model CostEvent {
+  id        String   @id @default(uuid())
+  run       Run      @relation(fields: [runId], references: [id])
+  runId     String
+  amount    Float
+  createdAt DateTime @default(now())
+}
+
+model Refactor {
+  id        String   @id @default(uuid())
+  scene     Scene    @relation(fields: [sceneId], references: [id])
+  sceneId   String
+  patches   Patch[]
+  createdAt DateTime @default(now())
+}
+
+model Patch {
+  id         String   @id @default(uuid())
+  refactor   Refactor @relation(fields: [refactorId], references: [id])
+  refactorId String
+  hunks      Hunk[]
+}
+
+model Hunk {
+  id       String @id @default(uuid())
+  patch    Patch  @relation(fields: [patchId], references: [id])
+  patchId  String
+  editSpans EditSpan[]
+}
+
+model EditSpan {
+  id     String @id @default(uuid())
+  hunk   Hunk   @relation(fields: [hunkId], references: [id])
+  hunkId String
+  start  Int
+  end    Int
+}
+
+model Snapshot {
+  id        String    @id @default(uuid())
+  scene     Scene     @relation(fields: [sceneId], references: [id])
+  sceneId   String
+  content   String
+  createdAt DateTime   @default(now())
+  sentences Sentence[]
+}
+
+model Sentence {
+  id         String   @id @default(uuid())
+  snapshot   Snapshot @relation(fields: [snapshotId], references: [id])
+  snapshotId String
+  text       String
+  order      Int
+}
+
+model StyleGuide {
+  id        String   @id @default(uuid())
+  project   Project  @relation(fields: [projectId], references: [id])
+  projectId String
+  name      String
+  rules     Json?
+  createdAt DateTime @default(now())
+}
+
+model User {
+  id          String       @id @default(uuid())
+  email       String       @unique
+  createdAt   DateTime     @default(now())
+  memberships Membership[]
+}
+
+model Membership {
+  id        String  @id @default(uuid())
+  user      User    @relation(fields: [userId], references: [id])
+  userId    String
+  project   Project @relation(fields: [projectId], references: [id])
+  projectId String
+  role      Role
+}
+
+model Budget {
+  id        String   @id @default(uuid())
+  project   Project  @relation(fields: [projectId], references: [id])
+  projectId String
+  amount    Float
+  createdAt DateTime @default(now())
+}
+
+model ProviderKey {
+  id        String   @id @default(uuid())
+  project   Project  @relation(fields: [projectId], references: [id])
+  projectId String
+  provider  String
+  apiKey    String
+  createdAt DateTime @default(now())
+}
+
+model SceneEntity {
+  scene   Scene  @relation(fields: [sceneId], references: [id])
+  sceneId String
+  entity  Entity @relation(fields: [entityId], references: [id])
+  entityId String
+  @@id([sceneId, entityId])
+}
+
+model Embedding {
+  id        String   @id @default(uuid())
+  scene     Scene?   @relation(fields: [sceneId], references: [id])
+  sceneId   String?
+  embedding Unsupported("vector")
+  createdAt DateTime @default(now())
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client'
+
+export const prisma = new PrismaClient()
+
+export async function seed() {
+  await prisma.$connect()
+}
+
+export async function reset() {
+  // basic reset helper for tests
+  await prisma.$executeRawUnsafe('TRUNCATE TABLE "Project" RESTART IDENTITY CASCADE;')
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,0 +1,10 @@
+import { prisma, seed } from './index.js'
+
+seed()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/packages/db/tests/health.test.ts
+++ b/packages/db/tests/health.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { prisma, reset } from '../src'
+
+describe('db health', () => {
+  it('creates a project', async () => {
+    await reset()
+    const project = await prisma.project.create({ data: { name: 'test', version: 1 } })
+    expect(project.name).toBe('test')
+  })
+})


### PR DESCRIPTION
## Summary
- scaffold `@nelo/db` package with Prisma schema covering projects, content, runs, and vector embeddings
- add raw migrations for pgvector and ivfflat index
- provide Docker compose for Postgres/Redis and seed/reset helpers

## Testing
- `DATABASE_URL=postgresql://nelo:nelo@localhost:5432/nelo pnpm --filter @nelo/db test --run` *(fails: Can't reach database server at `localhost:5432`)*
- `DATABASE_URL=postgresql://nelo:nelo@localhost:5432/nelo pnpm db:migrate` *(fails: Can't reach database server at `localhost:5432`)*
- `DATABASE_URL=postgresql://nelo:nelo@localhost:5432/nelo pnpm db:seed` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689ed04d62c08324a8573bbc35314b1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a database layer with an initial schema and vector support.
  - Added local infrastructure for Postgres and Redis with persistent volumes and auto-restart.
- Documentation
  - Added instructions to start local services and run database migration/seed commands.
- Chores
  - Added convenient scripts to run database migrations and seed data.
- Tests
  - Added a basic health check to validate database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->