### PR TITLE
feat: add context package

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@nelo/context",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "type": "module",
+  "dependencies": {
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,0 +1,9 @@
+import { ComposeContextOptionsSchema, type ComposeContextOptions } from './types';
+
+export function composeContext(options: ComposeContextOptions) {
+  ComposeContextOptionsSchema.parse(options);
+  return { segments: [], redactions: [] };
+}
+
+export { ComposeContextOptionsSchema } from './types';
+export type { ComposeContextOptions } from './types';

--- a/packages/context/src/types.ts
+++ b/packages/context/src/types.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const ComposeContextOptionsSchema = z.object({
+  template: z.string()
+});
+
+export type ComposeContextOptions = z.infer<typeof ComposeContextOptionsSchema>;

--- a/packages/context/test/context.spec.ts
+++ b/packages/context/test/context.spec.ts
@@ -1,0 +1,15 @@
+// @ts-ignore
+import { describe, it, expect } from 'vitest';
+import { composeContext } from '../src';
+
+describe('composeContext', () => {
+  it('validates options', () => {
+    // missing required template should throw
+    expect(() => composeContext({} as any)).toThrow();
+  });
+
+  it('returns empty arrays for segments and redactions', () => {
+    const result = composeContext({ template: 'hello' });
+    expect(result).toEqual({ segments: [], redactions: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add @nelo/context package
- validate composeContext options with Zod
- provide basic composeContext implementation and tests

## Testing
- `pnpm vitest run packages/context/test/context.spec.ts packages/context-engine/test/compose-context.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689ed5cd7a44832496e8575dd6838ad1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Context package to help build contexts from a provided template.
  * Added input validation to prevent invalid configurations.
  * Initial API returns a structured result with empty segments and redactions, ready for further use.

* **Tests**
  * Added unit tests covering validation failures when required options are missing.
  * Added tests confirming successful creation with a valid template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->