### PR TITLE
feat(api): add idempotency and version middlewares

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,17 @@
 import Fastify from 'fastify';
+import { scenesRoutes } from './scenes';
 
-const app = Fastify();
+export function buildApp() {
+  const app = Fastify();
+  app.get('/health', async () => ({ ok: true }));
+  app.register(scenesRoutes);
+  return app;
+}
 
-app.get('/health', async () => ({ ok: true }));
-
-app.listen({ port: 3001 }, (err, address) => {
-  if (err) throw err;
-  console.log(`API listening on ${address}`);
-});
+if (require.main === module) {
+  const app = buildApp();
+  app.listen({ port: 3001 }, (err, address) => {
+    if (err) throw err;
+    console.log(`API listening on ${address}`);
+  });
+}

--- a/apps/api/src/middlewares/idempotency.middleware.ts
+++ b/apps/api/src/middlewares/idempotency.middleware.ts
@@ -1,0 +1,25 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+const keys = new Set<string>();
+
+export function clearIdempotencyKeys() {
+  keys.clear();
+}
+
+export function idempotencyMiddleware(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: () => void
+) {
+  const key = request.headers['x-idempotency-key'];
+  if (!key || typeof key !== 'string') {
+    reply.status(400).send({ error: 'X-Idempotency-Key header required' });
+    return;
+  }
+  if (keys.has(key)) {
+    reply.status(409).send({ error: 'Duplicate request' });
+    return;
+  }
+  keys.add(key);
+  done();
+}

--- a/apps/api/src/middlewares/version.middleware.ts
+++ b/apps/api/src/middlewares/version.middleware.ts
@@ -1,0 +1,26 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+interface Scene { id: string; text: string; version: number }
+
+export function versionMiddleware(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: () => void
+) {
+  const ifMatch = request.headers['if-match'];
+  const scene = (request as any).scene as Scene | undefined;
+
+  if (!ifMatch || typeof ifMatch !== 'string') {
+    reply.status(400).send({ error: 'If-Match header required' });
+    return;
+  }
+  if (!scene) {
+    reply.status(404).send({ error: 'Scene not found' });
+    return;
+  }
+  if (String(scene.version) !== ifMatch) {
+    reply.status(412).send({ error: 'Version mismatch' });
+    return;
+  }
+  done();
+}

--- a/apps/api/src/scenes.ts
+++ b/apps/api/src/scenes.ts
@@ -1,0 +1,48 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { idempotencyMiddleware } from './middlewares/idempotency.middleware';
+import { versionMiddleware } from './middlewares/version.middleware';
+
+interface Scene { id: string; text: string; version: number }
+const scenes = new Map<string, Scene>();
+let nextId = 1;
+
+function loadScene(request: FastifyRequest, reply: FastifyReply, done: () => void) {
+  const id = (request.params as any).id;
+  const scene = scenes.get(String(id));
+  if (!scene) {
+    reply.status(404).send({ error: 'Scene not found' });
+    return;
+  }
+  (request as any).scene = scene;
+  done();
+}
+
+export async function scenesRoutes(app: FastifyInstance) {
+  app.post(
+    '/scenes',
+    { preHandler: idempotencyMiddleware },
+    async (request, reply) => {
+      const id = String(nextId++);
+      const text = (request.body as any)?.text ?? '';
+      const scene: Scene = { id, text, version: 1 };
+      scenes.set(id, scene);
+      reply.status(201).send(scene);
+    }
+  );
+
+  app.patch(
+    '/scenes/:id',
+    { preHandler: [loadScene, versionMiddleware] },
+    async (request, reply) => {
+      const scene = (request as any).scene as Scene;
+      const text = (request.body as any)?.text;
+      if (typeof text === 'string') {
+        scene.text = text;
+      }
+      scene.version += 1;
+      reply.send(scene);
+    }
+  );
+}
+
+export { scenes, Scene };

--- a/apps/api/test/idempotency.middleware.test.ts
+++ b/apps/api/test/idempotency.middleware.test.ts
@@ -1,0 +1,18 @@
+import Fastify from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { idempotencyMiddleware, clearIdempotencyKeys } from '../src/middlewares/idempotency.middleware';
+
+describe('idempotency middleware', () => {
+  afterEach(() => {
+    clearIdempotencyKeys();
+  });
+
+  it('returns 409 on duplicate idempotency key', async () => {
+    const app = Fastify();
+    app.post('/test', { preHandler: idempotencyMiddleware }, async () => ({ ok: true }));
+
+    await app.inject({ method: 'POST', url: '/test', headers: { 'x-idempotency-key': 'abc' } });
+    const res = await app.inject({ method: 'POST', url: '/test', headers: { 'x-idempotency-key': 'abc' } });
+    expect(res.statusCode).toBe(409);
+  });
+});

--- a/apps/api/test/scenes.e2e.test.ts
+++ b/apps/api/test/scenes.e2e.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildApp } from '../src';
+
+let app: ReturnType<typeof buildApp>;
+
+describe('scenes routes', () => {
+  beforeAll(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('requires X-Idempotency-Key on POST', async () => {
+    const res = await request(app.server).post('/scenes').send({ text: 'hello' });
+    expect(res.status).toBe(400);
+  });
+
+  it('detects duplicate X-Idempotency-Key', async () => {
+    const res1 = await request(app.server).post('/scenes').set('X-Idempotency-Key', 'dup').send({ text: 'a' });
+    expect(res1.status).toBe(201);
+    const res2 = await request(app.server).post('/scenes').set('X-Idempotency-Key', 'dup').send({ text: 'b' });
+    expect(res2.status).toBe(409);
+  });
+
+  it('requires If-Match on PATCH', async () => {
+    const create = await request(app.server).post('/scenes').set('X-Idempotency-Key', 'patch1').send({ text: 'initial' });
+    const id = create.body.id;
+    const res = await request(app.server).patch(`/scenes/${id}`).send({ text: 'change' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects mismatched If-Match', async () => {
+    const create = await request(app.server).post('/scenes').set('X-Idempotency-Key', 'patch2').send({ text: 'initial' });
+    const id = create.body.id;
+    const res = await request(app.server).patch(`/scenes/${id}`).set('If-Match', '999').send({ text: 'change' });
+    expect(res.status).toBe(412);
+  });
+
+  it('accepts correct If-Match', async () => {
+    const create = await request(app.server).post('/scenes').set('X-Idempotency-Key', 'patch3').send({ text: 'initial' });
+    const id = create.body.id;
+    const version = create.body.version;
+    const res = await request(app.server).patch(`/scenes/${id}`).set('If-Match', String(version)).send({ text: 'change' });
+    expect(res.status).toBe(200);
+    expect(res.body.version).toBe(version + 1);
+  });
+});

--- a/apps/api/test/version.middleware.test.ts
+++ b/apps/api/test/version.middleware.test.ts
@@ -1,0 +1,22 @@
+import Fastify from 'fastify';
+import { describe, expect, it } from 'vitest';
+import { versionMiddleware } from '../src/middlewares/version.middleware';
+
+describe('version middleware', () => {
+  it('returns 412 when If-Match does not match scene.version', async () => {
+    const app = Fastify();
+    const scene = { id: '1', text: 'hello', version: 1 };
+    app.patch('/scenes/:id', {
+      preHandler: [
+        (req, _reply, done) => {
+          (req as any).scene = scene;
+          done();
+        },
+        versionMiddleware
+      ]
+    }, async () => ({ ok: true }));
+
+    const res = await app.inject({ method: 'PATCH', url: '/scenes/1', headers: { 'if-match': '2' } });
+    expect(res.statusCode).toBe(412);
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"],
+  "include": ["src", "test"],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "db:seed": "pnpm --filter @nelo/db exec prisma db seed"
   },
   "devDependencies": {
+    "supertest": "^6.3.3",
     "typescript": "^5.3.0",
     "vitest": "^0.34.0"
   }


### PR DESCRIPTION
## Summary
- add X-Idempotency-Key middleware with duplicate detection
- add If-Match version check middleware for scenes
- cover with unit and supertest e2e tests

## Testing
- `pnpm --filter @nelo/db exec prisma generate`
- `pnpm vitest run` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689ed5d78f1c8324a88d2edc10b4a40a