### PR TITLE
feat(db): add seed script and demo data

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "db:migrate": "pnpm --filter @nelo/db exec prisma migrate deploy",
-    "db:seed": "pnpm --filter @nelo/db exec prisma db seed"
+    "db:seed": "pnpm --filter @nelo/db exec prisma db seed",
+    "seed": "pnpm --filter @nelo/db seed"
   },
   "devDependencies": {
     "typescript": "^5.3.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
     "generate": "prisma generate",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed",
+    "seed": "node --loader ts-node/esm seed.ts",
     "test": "vitest"
   },
   "dependencies": {

--- a/packages/db/seed-data.ts
+++ b/packages/db/seed-data.ts
@@ -1,0 +1,27 @@
+import type { Prisma } from '@prisma/client'
+
+export const secretScene: Prisma.SceneCreateWithoutChapterInput = {
+  order: 1,
+  content: 'The cake is a lie.',
+}
+
+export const demoProject: Prisma.ProjectCreateInput = {
+  name: 'Demo Project',
+  books: {
+    create: [
+      {
+        title: 'Demo Book',
+        chapters: {
+          create: [
+            {
+              title: 'Demo Chapter',
+              scenes: {
+                create: [secretScene],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'url'
+import { prisma } from './src/index.js'
+import { demoProject } from './seed-data.js'
+
+export async function seed() {
+  const project = await prisma.project.create({
+    data: demoProject,
+    include: {
+      books: {
+        include: {
+          chapters: {
+            include: { scenes: true },
+          },
+        },
+      },
+    },
+  })
+
+  const scene = project.books[0].chapters[0].scenes[0]
+  console.log(`Seeded demo project ${project.id}`)
+  console.log(`Seeded secret scene ${scene.id}`)
+  return { projectId: project.id, sceneId: scene.id }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  seed()
+    .catch((e) => {
+      console.error(e)
+      process.exit(1)
+    })
+    .finally(async () => {
+      await prisma.$disconnect()
+    })
+}

--- a/packages/db/tests/seed.test.ts
+++ b/packages/db/tests/seed.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { prisma, reset } from '../src/index.js'
+import { seed } from '../seed.js'
+import { demoProject, secretScene } from '../seed-data.js'
+
+describe('seed script', () => {
+  it('inserts demo project and secret scene', async () => {
+    await reset()
+    const { projectId, sceneId } = await seed()
+    const project = await prisma.project.findUnique({ where: { id: projectId } })
+    const scene = await prisma.scene.findUnique({ where: { id: sceneId } })
+    expect(project?.name).toBe(demoProject.name)
+    expect(scene?.content).toBe(secretScene.content)
+  })
+})


### PR DESCRIPTION
## Summary
- add demo project and secret scene seed data
- create seed script to insert demo data via Prisma
- expose seed npm script at repo root
- add test ensuring seed data persists

## Testing
- `pnpm --filter @nelo/db test run`
- `pnpm seed`


------
https://chatgpt.com/codex/tasks/task_e_689ed5daf0ac8324954cfd15e8da3a36