### PR TITLE
feat(api): add presence gateway

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,9 +6,11 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "fastify": "^4.22.0"
+    "fastify": "^4.22.0",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "@types/ws": "^8.5.8"
   }
 }

--- a/apps/api/src/gateway/events.test.ts
+++ b/apps/api/src/gateway/events.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { GATEWAY_EVENTS } from './events';
+
+describe('gateway events constants', () => {
+  it('should expose expected event names', () => {
+    expect(GATEWAY_EVENTS.HELLO).toBe('HELLO');
+    expect(GATEWAY_EVENTS.PING).toBe('PING');
+    expect(GATEWAY_EVENTS.PONG).toBe('PONG');
+  });
+});
+

--- a/apps/api/src/gateway/events.ts
+++ b/apps/api/src/gateway/events.ts
@@ -1,0 +1,17 @@
+export const GATEWAY_EVENTS = {
+  HELLO: 'HELLO',
+  PING: 'PING',
+  PONG: 'PONG',
+} as const;
+
+export type GatewayEvent = typeof GATEWAY_EVENTS[keyof typeof GATEWAY_EVENTS];
+
+export interface HelloPayload {
+  sessionId: string;
+}
+
+export type GatewayMessage =
+  | { event: typeof GATEWAY_EVENTS.HELLO; data: HelloPayload }
+  | { event: typeof GATEWAY_EVENTS.PING }
+  | { event: typeof GATEWAY_EVENTS.PONG };
+

--- a/apps/api/src/gateway/presence.gateway.test.ts
+++ b/apps/api/src/gateway/presence.gateway.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import WebSocket from 'ws';
+import { AddressInfo } from 'net';
+import { createPresenceGateway } from './presence.gateway';
+import { GATEWAY_EVENTS } from './events';
+
+describe('presence gateway', () => {
+  it('sends HELLO on connect and PONG for PING', async () => {
+    const wss = createPresenceGateway(0);
+    const port = (wss.address() as AddressInfo).port;
+    const ws = new WebSocket(`ws://localhost:${port}`);
+
+    const helloPromise = new Promise<any>((resolve) =>
+      ws.once('message', (data) => resolve(JSON.parse(data.toString())))
+    );
+    await new Promise((resolve) => ws.once('open', resolve));
+    const hello = await helloPromise;
+
+    expect(hello.event).toBe(GATEWAY_EVENTS.HELLO);
+    expect(hello.data.sessionId).toBeTypeOf('string');
+
+    const pongPromise = new Promise<any>((resolve) =>
+      ws.once('message', (data) => resolve(JSON.parse(data.toString())))
+    );
+    ws.send(JSON.stringify({ event: GATEWAY_EVENTS.PING }));
+    const pong = await pongPromise;
+
+    expect(pong.event).toBe(GATEWAY_EVENTS.PONG);
+
+    ws.close();
+    wss.close();
+  });
+});
+

--- a/apps/api/src/gateway/presence.gateway.ts
+++ b/apps/api/src/gateway/presence.gateway.ts
@@ -1,0 +1,31 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import { randomUUID } from 'crypto';
+import { GATEWAY_EVENTS, GatewayMessage } from './events';
+
+export function createPresenceGateway(port: number) {
+  const wss = new WebSocketServer({ port });
+
+  wss.on('connection', (ws: WebSocket) => {
+    const sessionId = randomUUID();
+    const hello: GatewayMessage = {
+      event: GATEWAY_EVENTS.HELLO,
+      data: { sessionId },
+    };
+    ws.send(JSON.stringify(hello));
+
+    ws.on('message', (data) => {
+      try {
+        const msg = JSON.parse(data.toString()) as GatewayMessage;
+        if (msg.event === GATEWAY_EVENTS.PING) {
+          const pong: GatewayMessage = { event: GATEWAY_EVENTS.PONG };
+          ws.send(JSON.stringify(pong));
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    });
+  });
+
+  return wss;
+}
+


### PR DESCRIPTION
## Summary
- add gateway event constants and types
- send HELLO with session id and handle PING/PONG in presence gateway
- test gateway events and ws behaviour

## Testing
- `pnpm vitest`
- `pnpm vitest apps/api/src/gateway/presence.gateway.test.ts apps/api/src/gateway/events.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_689ed5d54a7883249f9fc17010c23d3c