### PR TITLE
chore: set up workspace tooling and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "license": "MPL-2.0",
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r test",
     "db:migrate": "pnpm --filter @nelo/db exec prisma migrate deploy",
     "db:seed": "pnpm --filter @nelo/db exec prisma db seed"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@nelo/*": ["packages/*/src"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- delegate lint and test scripts from the root package
- share TypeScript config with baseUrl and `@nelo/*` path alias
- add CI workflow running lint and test via pnpm

## Testing
- `pnpm lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm test` *(fails: @prisma/client did not initialize yet)*
- `./bin/act -l` *(fails: Couldn't get a valid docker connection: no DOCKER_HOST and an invalid container socket '')*


------
https://chatgpt.com/codex/tasks/task_e_689ed5c807308324a0902de5e0044016