### PR TITLE
Potential fix for code scanning alert no. 15: Code injection

### DIFF
--- a/.github/workflows/dependency-resolver.yml
+++ b/.github/workflows/dependency-resolver.yml
@@ -161,6 +161,8 @@ jobs:
       
       - name: Run resolution
         if: steps.check.outputs.authorized == 'true'
+        env:
+          BODY: ${{ github.event.comment.body }}
         run: |
           chmod +x scripts/resolve-dependencies.sh
           
@@ -170,13 +172,13 @@ jobs:
             -f content='+1'
           
           # Check for dry-run flag
-          if echo "${{ github.event.comment.body }}" | grep -q "dry-run"; then
+          if echo "$BODY" | grep -q "dry-run"; then
             export DRY_RUN=true
             echo "Running in DRY RUN mode"
           fi
           
           # Check for verbose flag
-          if echo "${{ github.event.comment.body }}" | grep -q "verbose"; then
+          if echo "$BODY" | grep -q "verbose"; then
             export VERBOSE=true
             echo "Running in VERBOSE mode"
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/devongermano/nelo/security/code-scanning/15](https://github.com/devongermano/nelo/security/code-scanning/15)

To fix the problem, we should avoid interpolating user-controlled input directly into shell commands. Instead, we should assign the untrusted input to an environment variable and reference it using native shell variable syntax (e.g., `$BODY`) within the shell script. Specifically, in the `Run resolution` step, we should set an environment variable (e.g., `BODY`) to the value of `${{ github.event.comment.body }}` and then use `echo "$BODY"` in the shell script. This prevents code injection, as the shell will treat the value as a string rather than parsing it for commands.

The changes should be made in the `Run resolution` step (lines 163–182), specifically for the lines that use `${{ github.event.comment.body }}`. We need to:
- Add an `env:` block to set `BODY: ${{ github.event.comment.body }}`.
- Replace `echo "${{ github.event.comment.body }}"` with `echo "$BODY"` in the shell script.

No new methods or imports are needed, just the environment variable and the shell variable usage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Refactor
  - Streamlined how the dependency resolution workflow reads issue comment content, improving consistency and maintainability.
- Chores
  - Updated CI workflow to capture and reuse the issue comment body during dependency checks, reducing duplication in flag handling.
- Notes
  - This update affects internal automation only and does not alter application behavior for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->